### PR TITLE
Add changing port via env var PLEXPUSH_PORT

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,5 @@ $ PUSHOVER_USER=pushover-user-key PUSHOVER_TOKEN=pushover-api-token node index.j
 ```
 
 Finally, add the webhook to https://app.plex.tv/web/app#!/account/webhooks (it'll be http://localhost:10000).
+
+The app also accepts a custom port number from the `PLEXPUSH_PORT` environment variable.

--- a/index.js
+++ b/index.js
@@ -47,4 +47,4 @@ app.post('/', upload.single('thumb'), function (req, res, next) {
 	}
 });
 
-app.listen(10000);
+app.listen(process.env['PLEXPUSH_PORT'] || 10000);


### PR DESCRIPTION
Technically accepts a Unix socket path too, but I had issues getting that to work in practice (with getting nginx to proxy to it, and with express not deleting the socket file when stopped by Upstart).

Passing a port number works fine.