### PR TITLE
Add episode numbers in SxEE format

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 In order to run this app:
  
-- Install [node.js](https://nodejs.org/en/).
+- Install [node.js](https://nodejs.org/en/) (version 8 or above).
 - Clone the repository.
 - Install dependencies using `npm install`.
 

--- a/index.js
+++ b/index.js
@@ -24,10 +24,12 @@ app.post('/', upload.single('thumb'), function (req, res, next) {
 			msg.message = payload.Metadata.title;
 		}
 		else if(payload.Metadata.type === 'episode') {
-			// TV Shows
+			// TV Shows - note padStart() requires node 8, or the --harmony flag in node 7
 			msg.title = "Plex: " + payload.Account.title;
 			msg.message = "Show: " + payload.Metadata.grandparentTitle +
-							"\nEpisode: " + payload.Metadata.title;
+					"\nEpisode: " + payload.Metadata.parentIndex +
+					"x" + payload.Metadata.index.toString().padStart(2, "0") +
+					" " + payload.Metadata.title;
 		}
 
 		msg.url = "https://app.plex.tv/web/app#!/server/" + 


### PR DESCRIPTION
Requires Node 8 because I used the padStart() method added in ES2017 (though it is technically available with the `--harmony` flag in Node 7).

I can reimplement with a more backwards-compatible padding function (meaning steal one from SO :stuck_out_tongue:) if you want.