### PR TITLE
Add 405 Method Not Allowed for GET requests

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ var p = new push( {
 });
 
 app.get('*', function (req, res) {
-	res.status(405).end();
+	res.sendStatus(405);
 });
 
 app.post('/', upload.single('thumb'), function (req, res, next) {

--- a/index.js
+++ b/index.js
@@ -12,6 +12,10 @@ var p = new push( {
 	token: process.env['PUSHOVER_TOKEN'],
 });
 
+app.get('*', function (req, res) {
+	res.status(405).end();
+});
+
 app.post('/', upload.single('thumb'), function (req, res, next) {
 	var payload = JSON.parse(req.body.payload);
 


### PR DESCRIPTION
There are plenty of HTTP verbs, but GET is the one most likely to be sent, e.g. by a user poking around with a browser.

Maybe this should send back an error string along with the code, I don't know. I'll think about it before merging.

(PS @grahams, I do this a lot: open PRs on my own repos for stuff I'm working on. Doesn't necessarily mean it's merge-ready, but it helps remind me what I'm working on. I don't do it for other people's repos because it can messy from the maintainers' PoV… 😆 )