### PR TITLE
Respond 501 Not Implemented on unhandled events

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,6 +51,10 @@ app.post('/', upload.single('thumb'), function (req, res, next) {
 	
 		res.sendStatus(200);
 	}
+	else {
+		// Unknown action, send a "Not Implemented" error response
+		res.sendStatus(501);
+	}
 });
 
 app.listen(process.env['PLEXPUSH_PORT'] || 10000);


### PR DESCRIPTION
Currently the webhook only handles `media.play` events. Any other event type now sends an appropriate HTTP status code indicating that fact (`501 Not Implemented`), instead of just closing the connection without sending a response.