### PR TITLE
Send HTTP 415 for unsupported media types

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,6 +35,11 @@ app.post('/', upload.single('thumb'), function (req, res, next) {
 					"x" + payload.Metadata.index.toString().padStart(2, "0") +
 					" " + payload.Metadata.title;
 		}
+		else {
+			// "Unsupported Media Type" is a good in-joke for this, isn't it?
+			res.sendStatus(415);
+			return;
+		}
 
 		msg.url = "https://app.plex.tv/web/app#!/server/" + 
 					payload.Server.uuid + "/details/" + 


### PR DESCRIPTION
Bit of an in-joke for HTTP nerds, since HTTP status code 415 is actually defined as "Unsupported Media Type".

I may or may not decide to replace it with 501 Not Implemented or another 5xx code to be proper… Still thinking.