### PR TITLE
Append client name to notification title

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,6 +36,7 @@ app.post('/', upload.single('thumb'), function (req, res, next) {
 					" " + payload.Metadata.title;
 		}
 
+		msg.title += " via " + payload.Player.title + " (" + ((payload.Player.local) ? "local" : "remote") + ")";
 		msg.url = "https://app.plex.tv/web/app#!/server/" + 
 					payload.Server.uuid + "/details/" + 
 					encodeURIComponent(payload.Metadata.key);


### PR DESCRIPTION
Also includes whether the client is local or remote. Pushover gives us 250 characters to play with in notification titles; why not use them?

The only unfortunate part is, PMS passes the client's device-defined name but not the name/type of the client. So this only enables adding e.g. "via computername (local)", not "via Plex Media Player (local)".