### PR TITLE
Update Plex Web URL to /desktop

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,6 @@ Then run the app as follows:
 $ PUSHOVER_USER=pushover-user-key PUSHOVER_TOKEN=pushover-api-token node index.js
 ```
 
-Finally, add the webhook to https://app.plex.tv/web/app#!/account/webhooks (it'll be http://localhost:10000).
+Finally, add the webhook to https://app.plex.tv/desktop#!/account/webhooks (it'll be http://localhost:10000).
 
 The app also accepts a custom port number from the `PLEXPUSH_PORT` environment variable.

--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ app.post('/', upload.single('thumb'), function (req, res, next) {
 		}
 
 		msg.title += " via " + payload.Player.title + " (" + ((payload.Player.local) ? "local" : "remote") + ")";
-		msg.url = "https://app.plex.tv/web/app#!/server/" + 
+		msg.url = "https://app.plex.tv/desktop#!/server/" + 
 					payload.Server.uuid + "/details/" + 
 					encodeURIComponent(payload.Metadata.key);
 		msg.url_title = "View details";


### PR DESCRIPTION
I think this change should just close #5 since who knows when (or if) Plex will change their URLs again. Should they add a mobile version of Plex Web, that can be addressed separately.