### PR TITLE
Lower notification priority to avoid nuisance

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,6 +52,7 @@ app.post('/', upload.single('thumb'), function (req, res, next) {
                     payload.Server.uuid + "/details/" + 
                     encodeURIComponent(payload.Metadata.key);
         msg.url_title = "View details";
+        msg.priority = -1;
 
         p.send( msg, function( err, result) {
             if( err ) {


### PR DESCRIPTION
Especially with notifications being sent for music tracks, Pushover's default notification priority can get pretty noisy. At this priority level, the app will not make noise or vibrate, but the notifications still appear when checking notifications on a registered device.

I made this change at least a month ago, actually, but forgot about committing it. (That's what I get for changing things on the server to test, instead of committing in my local repo and pushing/pulling…)