### PR TITLE
Ignore GET requests that aren't for '/'

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ var p = new push( {
     token: process.env['PUSHOVER_TOKEN'],
 });
 
-app.get('*', function (req, res) {
+app.get('/', function (req, res) {
     res.header('Allow', 'POST').sendStatus(405);
 });
 


### PR DESCRIPTION
This prevents returning 405 Method Not Allowed for literally everything, including stuff that definitely doesn't exist (like favicon.ico).

Going to conflict with #25, but _c'est la vie_.