### PR TITLE
Suppress Express's X-Powered-By header

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,8 @@ var express = require('express')
 
 var upload = multer({ dest: '/tmp/' });
 var app = express();
+app.disable('x-powered-by');
+// No need to advertise what framework we're using to network fuzzers
 
 var push = require('pushover-notifications');
 


### PR DESCRIPTION
It's not necessary to advertise what framework we use. If a network scanner wants to know, it probably has heuristics for figuring out what HTTP server we use on its own, thank you very much.